### PR TITLE
mx4: clarify docs and params being used to parse returned metadata

### DIFF
--- a/mx4.cpp
+++ b/mx4.cpp
@@ -1,10 +1,13 @@
 #include "sap.h"
 #include "mx4.h"
 
-MX4MetadataWrapper GetMX4MetadataFromBuffer(SapBufferWrapper buf, int width, int height) {
+// GetMX4MetadataFromBuffer returns a struct of MX4Metadata that has been parsed from the buffer
+// of data passed into this function. Also pass in the width of the image area of the buffer, along with the
+// line number (1-indexed) of the buffer for which you want the metadata.
+MX4MetadataWrapper GetMX4MetadataFromBuffer(SapBufferWrapper buf, int width, int line) {
 	int numRead;
 	MX4MetadataWrapper metadata = new MX4Metadata;
-	buf->ReadLine(width, height-1, width+64-1, height-1, metadata, &numRead);
+	buf->ReadLine(width, line-1, width-1+MX4MetadataSize, line-1, metadata, &numRead);
 	return metadata;
 }
 

--- a/mx4.go
+++ b/mx4.go
@@ -11,15 +11,20 @@ import (
 	"unsafe"
 )
 
+// MX4Metadata is the metadata such as the line count and encoder count for each
+// captured frame.
 type MX4Metadata struct {
 	// C.MX4MetadataWrapper
 	p unsafe.Pointer
 }
 
-func GetMX4MetadataFromBuffer(buf SapBuffer, width, height int) MX4Metadata {
-	return MX4Metadata{p: unsafe.Pointer(C.GetMX4MetadataFromBuffer((C.SapBufferWrapper)(buf.p), C.int(width), C.int(height)))}
+// GetMX4MetadataFromBuffer returns the MX4Metadata for a buffer. Pass in the width of the
+// image part of the buffer, and the line number (1-indexed) for which you want the metadata.
+func GetMX4MetadataFromBuffer(buf SapBuffer, width, line int) MX4Metadata {
+	return MX4Metadata{p: unsafe.Pointer(C.GetMX4MetadataFromBuffer((C.SapBufferWrapper)(buf.p), C.int(width), C.int(line)))}
 }
 
+// Close cleans up any memory that has been allocated for the MX4Metadata.
 func (mta MX4Metadata) Close() {
 	C.MX4Metadata_Close((C.MX4MetadataWrapper)(mta.p))
 }

--- a/mx4.h
+++ b/mx4.h
@@ -8,6 +8,8 @@
 extern "C" {
 #endif
 
+#define MX4MetadataSize 64
+
 typedef struct
 {
   ULONGLONG shaftEncoderCount;
@@ -23,7 +25,7 @@ typedef struct
 
 typedef MX4Metadata* MX4MetadataWrapper;
 
-MX4MetadataWrapper GetMX4MetadataFromBuffer(SapBufferWrapper buf, int width, int height);
+MX4MetadataWrapper GetMX4MetadataFromBuffer(SapBufferWrapper buf, int width, int line);
 void MX4Metadata_Close(MX4MetadataWrapper mta);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This PR clarifies the doc comments and params being used to parse returned MX4 metadata.